### PR TITLE
correction of richfaces.jar detection

### DIFF
--- a/metamer/application/src/main/java/org/richfaces/tests/metamer/Attributes.java
+++ b/metamer/application/src/main/java/org/richfaces/tests/metamer/Attributes.java
@@ -664,7 +664,7 @@ public final class Attributes implements Map<String, Attribute>, Serializable {
 
             while (fileUrls.hasMoreElements()) {
                 URL url = fileUrls.nextElement();
-                if (url.getPath().contains("richfaces")) {
+                if (url.getPath().matches(".*richfaces[^/]+jar.*")) {
                     configFile = url;
                 }
             }


### PR DESCRIPTION
Allows to pick up correct faces-config.xml.

The detection didn't work for me when path contained /richfaces/ and the weld's faces-config.xml was picked up instead.
