### PR TITLE
fix image resource locations

### DIFF
--- a/metamer/application/src/main/webapp/components/richContextMenu/simple.xhtml
+++ b/metamer/application/src/main/webapp/components/richContextMenu/simple.xhtml
@@ -91,7 +91,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <rich:menuItem id="menuItem31"  label="Save" action="#{richContextMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                     <rich:menuItem id="menuItem32" label="Save All" action="#{richContextMenuBean.doSaveAll}">
                         <f:facet name="icon">
-                            <h:graphicImage library="images/icons" name="save_all.gif" />
+                            <h:graphicImage library="images" name="icons/save_all.gif" />
                         </f:facet>
                     </rich:menuItem>
                 </rich:menuGroup>
@@ -102,7 +102,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <rich:menuItem id="menuItem41" label="Save" action="#{richContextMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                     <rich:menuItem id="menuItem42" label="Save All" action="#{richContextMenuBean.doSaveAll}" >
                         <f:facet name="icon">
-                            <h:graphicImage library="images/icons" name="save_all.gif" />
+                            <h:graphicImage library="images" name="icons/save_all.gif" />
                         </f:facet>
                     </rich:menuItem>
                     <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richDropDownMenu/rf-11730_1.xhtml
+++ b/metamer/application/src/main/webapp/components/richDropDownMenu/rf-11730_1.xhtml
@@ -71,7 +71,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                <rich:toolbarGroup id="openedTabs" location="left">
                   <rich:dropDownMenu id="menu-opened-tabs">
                       <f:facet name="label">
-                         <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                         <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                       </f:facet>
        
                       <rich:menuItem id="menuItem1" label="New" action="#{richDropDownMenuBean.doNew}" icon="/resources/images/icons/create_doc.gif"/>
@@ -82,7 +82,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                          <rich:menuItem id="menuItem31" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                          <rich:menuItem id="menuItem32"  label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                             <f:facet name="icon">
-                                <h:graphicImage library="images/icons" name="save_all.gif" />
+                                <h:graphicImage library="images" name="icons/save_all.gif" />
                             </f:facet>
                          </rich:menuItem>
                       </rich:menuGroup>
@@ -93,7 +93,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richDropDownMenu/rf-11730_2.xhtml
+++ b/metamer/application/src/main/webapp/components/richDropDownMenu/rf-11730_2.xhtml
@@ -71,7 +71,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                <rich:toolbarGroup id="openedTabs" location="left">
                   <rich:dropDownMenu id="menu-opened-tabs">
                       <f:facet name="label">
-                         <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                         <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                       </f:facet>
        
                       <rich:menuItem id="menuItem1" label="New" action="#{richDropDownMenuBean.doNew}" icon="/resources/images/icons/create_doc.gif"/>
@@ -82,7 +82,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                          <rich:menuItem id="menuItem31" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                          <rich:menuItem id="menuItem32"  label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                             <f:facet name="icon">
-                                <h:graphicImage library="images/icons" name="save_all.gif" />
+                                <h:graphicImage library="images" name="icons/save_all.gif" />
                             </f:facet>
                          </rich:menuItem>
                       </rich:menuGroup>
@@ -93,7 +93,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richDropDownMenu/sideMenu.xhtml
+++ b/metamer/application/src/main/webapp/components/richDropDownMenu/sideMenu.xhtml
@@ -92,7 +92,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                                     >
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -105,7 +105,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <r:menuItem id="menuItem31" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <r:menuItem id="menuItem32" label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </r:menuItem>
                         </r:menuGroup>
@@ -116,7 +116,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <r:menuItem id="menuItem41" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <r:menuItem id="menuItem42" label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </r:menuItem>
                             <r:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richDropDownMenu/topMenu.xhtml
+++ b/metamer/application/src/main/webapp/components/richDropDownMenu/topMenu.xhtml
@@ -91,7 +91,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                                        >
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -104,7 +104,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem31" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem32"  label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                         </rich:menuGroup>
@@ -115,7 +115,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richDropDownMenu/withLabel.xhtml
+++ b/metamer/application/src/main/webapp/components/richDropDownMenu/withLabel.xhtml
@@ -99,7 +99,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem31" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem32"  label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                         </rich:menuGroup>
@@ -110,7 +110,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" action="#{richDropDownMenuBean.doSave}" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" action="#{richDropDownMenuBean.doSaveAll}">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richMenuGroup/facets.xhtml
+++ b/metamer/application/src/main/webapp/components/richMenuGroup/facets.xhtml
@@ -59,7 +59,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <rich:dropDownMenu id="menu1" mode="ajax">
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -72,7 +72,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem31" label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem32" label="Save All">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                         </rich:menuGroup>
@@ -117,7 +117,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" >
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richMenuGroup/simple.xhtml
+++ b/metamer/application/src/main/webapp/components/richMenuGroup/simple.xhtml
@@ -59,7 +59,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <r:dropDownMenu id="menu1" mode="ajax">
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -72,7 +72,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <r:menuItem id="menuItem31" label="Save" icon="/resources/images/icons/save.gif" />
                             <r:menuItem id="menuItem32" label="Save All">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </r:menuItem>
                         </r:menuGroup>
@@ -110,7 +110,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <r:menuItem id="menuItem41" label="Save" icon="/resources/images/icons/save.gif" />
                             <r:menuItem id="menuItem42" label="Save All" >
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </r:menuItem>
                             <r:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richMenuItem/facets.xhtml
+++ b/metamer/application/src/main/webapp/components/richMenuItem/facets.xhtml
@@ -59,7 +59,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <rich:dropDownMenu id="menu1" mode="ajax">
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -113,7 +113,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem31"  label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem32" label="Save All">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                         </rich:menuGroup>
@@ -124,7 +124,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" >
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richMenuItem/simple.xhtml
+++ b/metamer/application/src/main/webapp/components/richMenuItem/simple.xhtml
@@ -59,7 +59,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <rich:dropDownMenu id="menu1" mode="ajax">
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -106,7 +106,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem31"  label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem32" label="Save All">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                         </rich:menuGroup>
@@ -117,7 +117,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem id="menuItem41" label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem id="menuItem42" label="Save All" >
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem id="menuItem43" label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richMenuSeparator/simple.xhtml
+++ b/metamer/application/src/main/webapp/components/richMenuSeparator/simple.xhtml
@@ -59,7 +59,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                     <rich:dropDownMenu id="menu1" mode="ajax">
                         <f:facet name="label">
                             <h:panelGroup>
-                                <h:graphicImage library="images/icons" name="copy.gif" styleClass="pic" />
+                                <h:graphicImage library="images" name="icons/copy.gif" styleClass="pic" />
                                 <h:outputText value="File" />
                             </h:panelGroup>
                         </f:facet>
@@ -72,7 +72,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem  label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem  label="Save All">
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                         </rich:menuGroup>
@@ -84,7 +84,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                             <rich:menuItem  label="Save" icon="/resources/images/icons/save.gif" />
                             <rich:menuItem  label="Save All" >
                                 <f:facet name="icon">
-                                    <h:graphicImage library="images/icons" name="save_all.gif" />
+                                    <h:graphicImage library="images" name="icons/save_all.gif" />
                                 </f:facet>
                             </rich:menuItem>
                             <rich:menuItem  label="Send Online" icon="/resources/images/icons/save.gif" disabled="true" />

--- a/metamer/application/src/main/webapp/components/richToolbar/simple.xhtml
+++ b/metamer/application/src/main/webapp/components/richToolbar/simple.xhtml
@@ -75,15 +75,15 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                           >
 
                 <rich:toolbarGroup>
-                    <h:graphicImage id="createDocument" library="images/icons" name="create_doc.gif" styleClass="pic" />
-                    <h:graphicImage id="createFolder" library="images/icons" name="create_folder.gif" styleClass="pic" />
-                    <h:graphicImage id="copy" library="images/icons" name="copy.gif" styleClass="pic" />
+                    <h:graphicImage id="createDocument" library="images" name="icons/create_doc.gif" styleClass="pic" />
+                    <h:graphicImage id="createFolder" library="images" name="icons/create_folder.gif" styleClass="pic" />
+                    <h:graphicImage id="copy" library="images" name="icons/copy.gif" styleClass="pic" />
                 </rich:toolbarGroup>
 
                 <rich:toolbarGroup>
-                    <h:graphicImage id="save" library="images/icons" name="save.gif" styleClass="pic" />
-                    <h:graphicImage id="saveAs" library="images/icons" name="save_as.gif" styleClass="pic" />
-                    <h:graphicImage id="saveAll" library="images/icons" name="save_all.gif" styleClass="pic" />
+                    <h:graphicImage id="save" library="images" name="icons/save.gif" styleClass="pic" />
+                    <h:graphicImage id="saveAs" library="images" name="icons/save_as.gif" styleClass="pic" />
+                    <h:graphicImage id="saveAll" library="images" name="icons/save_all.gif" styleClass="pic" />
                 </rich:toolbarGroup>
 
                 <rich:toolbarGroup location="right">

--- a/metamer/application/src/main/webapp/components/richToolbarGroup/simple.xhtml
+++ b/metamer/application/src/main/webapp/components/richToolbarGroup/simple.xhtml
@@ -71,12 +71,12 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
                                    onitemmouseup="#{richToolbarGroupBean.attributes['onitemmouseup'].value}"
                                    rendered="#{richToolbarGroupBean.attributes['rendered'].value}"
                                    >
-                    <h:graphicImage id="createDocument" library="images/icons" name="create_doc.gif" styleClass="pic" />
-                    <h:graphicImage id="createFolder" library="images/icons" name="create_folder.gif" styleClass="pic" />
-                    <h:graphicImage id="copy" library="images/icons" name="copy.gif" styleClass="pic" />
-                    <h:graphicImage id="save" library="images/icons" name="save.gif" styleClass="pic" />
-                    <h:graphicImage id="saveAs" library="images/icons" name="save_as.gif" styleClass="pic" />
-                    <h:graphicImage id="saveAll" library="images/icons" name="save_all.gif" styleClass="pic" />
+                    <h:graphicImage id="createDocument" library="images" name="icons/create_doc.gif" styleClass="pic" />
+                    <h:graphicImage id="createFolder" library="images" name="icons/create_folder.gif" styleClass="pic" />
+                    <h:graphicImage id="copy" library="images" name="icons/copy.gif" styleClass="pic" />
+                    <h:graphicImage id="save" library="images" name="icons/save.gif" styleClass="pic" />
+                    <h:graphicImage id="saveAs" library="images" name="icons/save_as.gif" styleClass="pic" />
+                    <h:graphicImage id="saveAll" library="images" name="icons/save_all.gif" styleClass="pic" />
                 </rich:toolbarGroup>
 
                 <rich:toolbarGroup id="group2" location="right">

--- a/metamer/application/src/main/webapp/components/richTooltip/rf-14136.xhtml
+++ b/metamer/application/src/main/webapp/components/richTooltip/rf-14136.xhtml
@@ -35,7 +35,7 @@
                 </ul>
             </p>
             <br/>
-            <h:graphicImage id="imageWithTooltip" library="images/icons" name="create_doc.gif" styleClass="pic">
+            <h:graphicImage id="imageWithTooltip" library="images" name="icons/create_doc.gif" styleClass="pic">
                 <rich:tooltip id="tooltip" hideDelay="1500">Tooltip text</rich:tooltip>
             </h:graphicImage>
         </ui:define>


### PR DESCRIPTION
JSF apparently doesn't allow slash in a library name (starting from Mojarra 2.2.12/WildFly 10, in MyFaces this has been the case for a while - [RF-12415](https://issues.jboss.org/browse/RF-12415)), putting the subfolder in the file name is ok though, and works with earlier versions. (This doesn't affect RichFaces resources)