### PR TITLE
Improvements for making this testsuite compatible with EAP 7.1

### DIFF
--- a/metamer/application/pom.xml
+++ b/metamer/application/pom.xml
@@ -57,7 +57,7 @@ FSF site: http://www.fsf.org. -->
             <artifactId>cdi-api</artifactId>
             <version>1.1</version>
         </dependency>
-        <dependency>
+        <!--dependency>
             <groupId>org.jboss.weld.servlet</groupId>
             <artifactId>weld-servlet</artifactId>
             <scope>compile</scope>
@@ -67,7 +67,7 @@ FSF site: http://www.fsf.org. -->
                     <artifactId>weld-build-config</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
+        </dependency-->
 
         <dependency>
             <groupId>javax.el</groupId>
@@ -143,6 +143,19 @@ FSF site: http://www.fsf.org. -->
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-process-controller</artifactId>
             <version>7.2.0.Final</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.3.0.Final</version>
             <scope>provided</scope>
         </dependency>
 

--- a/metamer/application/src/main/webapp/META-INF/MANIFEST.MF
+++ b/metamer/application/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 Class-Path: 
-Dependencies: org.slf4j,org.jboss.as.process-controller,org.jboss.as.controller-client,org.jboss.dmr
+Dependencies: org.slf4j,org.jboss.as.process-controller,org.jboss.as.controller-client,org.jboss.dmr,org.jboss.logging

--- a/metamer/ftest/pom.xml
+++ b/metamer/ftest/pom.xml
@@ -58,6 +58,12 @@ FSF site: http://www.fsf.org. -->
             <version>${project.version}</version>
             <classifier>classes</classifier>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <!-- Arquillian dependencies -->
         <dependency>
@@ -65,6 +71,12 @@ FSF site: http://www.fsf.org. -->
             <artifactId>graphene-webdriver</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
@@ -76,6 +88,12 @@ FSF site: http://www.fsf.org. -->
             <artifactId>richfaces-page-fragments</artifactId>
             <version>${version.richfaces}</version>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Resolution of JAR libraries into WAR archive -->
@@ -83,6 +101,12 @@ FSF site: http://www.fsf.org. -->
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -121,6 +145,12 @@ FSF site: http://www.fsf.org. -->
             <artifactId>richfaces-qa-maven-plugin</artifactId>
             <scope>test</scope>
             <version>${project.version}</version>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <!-- see the https://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode -->
         <dependency>
@@ -142,6 +172,12 @@ FSF site: http://www.fsf.org. -->
             <groupId>org.eu.ingwar.tools</groupId>
             <artifactId>arquillian-suite-extension</artifactId>
             <scope>test</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.google.guava</groupId>
+            		<artifactId>guava</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -149,12 +185,40 @@ FSF site: http://www.fsf.org. -->
             <artifactId>testng</artifactId>
         </dependency>
 
-        <!-- Command line interface for JBoss containers -->
+        <!--Creaper-->
         <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-cli</artifactId>
-            <version>8.2.1.Final</version>
-            <scope>test</scope>
+            <groupId>org.wildfly.extras.creaper</groupId>
+            <artifactId>creaper-core</artifactId>
+            <version>${version.org.wildfly.extras.creaper}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>com.google.guava</groupId>
+                	<artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.extras.creaper</groupId>
+            <artifactId>creaper-commands</artifactId>
+            <version>${version.org.wildfly.extras.creaper}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                	<groupId>com.google.guava</groupId>
+                	<artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+        	<groupId>com.google.guava</groupId>
+        	<artifactId>guava</artifactId>
         </dependency>
     </dependencies>
 

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/extension/creaper/ApplyPatch.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/extension/creaper/ApplyPatch.java
@@ -1,0 +1,175 @@
+package org.richfaces.tests.metamer.ftest.extension.creaper;
+
+import org.apache.commons.lang.StringUtils;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.offline.OfflineCommand;
+import org.wildfly.extras.creaper.core.offline.OfflineCommandContext;
+import org.wildfly.extras.creaper.core.online.CliException;
+import org.wildfly.extras.creaper.core.online.OnlineCommand;
+import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Command for patch application. OfflineCommand only for standalone mode!
+ */
+public final class ApplyPatch implements OnlineCommand, OfflineCommand {
+    private final String patchPath;
+    private final Boolean overrideAll;
+    private final Boolean overrideModules;
+    private final List<String> overridePaths;
+    private final List<String> preservePaths;
+
+    private ApplyPatch(Builder builder) {
+        this.patchPath = builder.patchPath;
+        this.overrideAll = builder.overrideAll;
+        this.overrideModules = builder.overrideModules;
+        this.overridePaths = builder.overridePaths;
+        this.preservePaths = builder.preservePaths;
+    }
+
+    @Override
+    public void apply(OnlineCommandContext ctx) throws CliException, CommandFailedException, IOException {
+        StringBuilder cmd = buildCliCommandBase();
+        if (ctx.options.isDomain) {
+            cmd.append(" --host=");
+            cmd.append(ctx.options.defaultHost);
+        }
+        ctx.client.executeCli(cmd.toString());
+    }
+
+    @Override
+    public String toString() {
+        return "ApplyPatch " + patchPath;
+    }
+
+    @Override
+    public void apply(OfflineCommandContext ctx) throws Exception {
+        executeCliOffline(buildCliCommandBase().toString(), ctx);
+    }
+
+    private StringBuilder buildCliCommandBase() {
+        StringBuilder cmd = new StringBuilder("patch apply " + patchPath);
+        if (overrideAll != null && overrideAll) {
+            cmd.append(" --override-all");
+        }
+        if (overrideModules != null && overrideModules) {
+            cmd.append(" --override-modules");
+        }
+        if (overridePaths != null && !overridePaths.isEmpty()) {
+            cmd.append(" --override=");
+            cmd.append(PatchingConversions.flatten(overridePaths));
+        }
+        if (preservePaths != null && !preservePaths.isEmpty()) {
+            cmd.append(" --preserve=");
+            cmd.append(PatchingConversions.flatten(preservePaths));
+        }
+        return cmd;
+    }
+
+    public static final class Builder {
+        private final String patchPath;
+        private Boolean overrideAll;
+        private Boolean overrideModules;
+        private List<String> overridePaths;
+        private List<String> preservePaths;
+
+        /**
+         * @param patchPath path to patch file
+         */
+        public Builder(String patchPath) {
+            this.patchPath = patchPath;
+        }
+
+        /**
+         * @param patchFile patch file
+         */
+        public Builder(File patchFile) {
+            this.patchPath = patchFile.getAbsolutePath();
+        }
+
+        /**
+         * Sets whether all conflicts should be automatically resolved by overriding the data using those from patch.
+         */
+        public Builder overrideAll(boolean overrideAll) {
+            this.overrideAll = overrideAll;
+            return this;
+        }
+
+        /**
+         * Sets whether modules shall be overridden when there is conflict in the module.
+         */
+        public Builder overrideModules(boolean overrideModules) {
+            this.overrideModules = overrideModules;
+            return this;
+        }
+
+        /**
+         * Adds specified paths to the list of paths which shall be overridden.
+         * For more details, see the {@code --override} option of the {@code patch apply} CLI command.
+         */
+        public Builder overridePaths(String... pathsToOverride) {
+            if (this.overridePaths == null && pathsToOverride != null) {
+                this.overridePaths = new ArrayList<String>();
+            }
+            if (pathsToOverride != null) {
+                this.overridePaths.addAll(Arrays.asList(pathsToOverride));
+            }
+            return this;
+
+        }
+
+        /**
+         * Adds paths to list of paths which should be preserved.
+         * For more details, see the {@code --preserve} option of the {@code patch apply} CLI command.
+         */
+        public Builder preservePaths(String... pathsToPreserve) {
+            if (this.preservePaths == null && pathsToPreserve != null) {
+                this.preservePaths = new ArrayList<String>();
+            }
+            if (pathsToPreserve != null) {
+                this.preservePaths.addAll(Arrays.asList(pathsToPreserve));
+            }
+            return this;
+        }
+
+        public ApplyPatch build() {
+            return new ApplyPatch(this);
+        }
+    }
+
+    private boolean isOnWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+
+    private void executeCliOffline(String cliCommand, OfflineCommandContext ctx) throws IOException, InterruptedException {
+        String configDirPath = ctx.client.options().configurationDirectory().getAbsolutePath();
+
+        List<String> rootDirPathSteps = new ArrayList<String>(Arrays.asList(configDirPath.split(File.separator)));
+
+        String rootDirPath = StringUtils.join(rootDirPathSteps.subList(0, rootDirPathSteps.size() - 2), File.separator);
+
+        System.out.println("Root path = '" + rootDirPath + "'.");
+
+        StringBuilder command = new StringBuilder()
+                .append(rootDirPath)
+                .append(File.separator)
+                .append("bin")
+                .append(File.separator)
+                .append("jboss-cli")
+                .append(isOnWindows() ? ".bat" : ".sh");
+
+        Process p = Runtime.getRuntime().exec("chmod +x " + command.toString());
+        p.waitFor();
+
+        command.append(" command=\"")
+            .append(cliCommand)
+            .append("\"");
+
+        Runtime.getRuntime().exec(command.toString());
+    }
+}

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/extension/creaper/PatchingConversions.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/extension/creaper/PatchingConversions.java
@@ -1,0 +1,44 @@
+package org.richfaces.tests.metamer.ftest.extension.creaper;
+
+import java.util.List;
+
+/**
+ * Helper class containing support methods for {@link ApplyPatch}.
+ */
+final class PatchingConversions {
+    private PatchingConversions() {} // avoid instantiation
+
+    /**
+     * Converts list to single string using comma as delimiter.
+     */
+    public static String flatten(List<String> list) {
+        if (list == null) {
+            throw new IllegalArgumentException("Argument list must be provided");
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String p : list) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(p);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Converts list of paths to string with comma as delimiter, with escaping of backslashes.
+     */
+    public static String flattenAndEscape(List<String> paths) {
+        if (paths == null) {
+            throw new IllegalArgumentException("Argument paths must be provided");
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String p : paths) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(p.replaceAll("\\\\", "\\\\\\\\")); //FIXME correct path escaping on Windows?
+        }
+        return sb.toString();
+    }
+}

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/richDragSource/TestDragSource.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/richDragSource/TestDragSource.java
@@ -21,18 +21,8 @@
  */
 package org.richfaces.tests.metamer.ftest.richDragSource;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
+import com.google.common.collect.Lists;
 import org.jboss.arquillian.graphene.GrapheneElement;
-import org.jboss.as.cli.CommandLineException;
 import org.openqa.selenium.interactions.Actions;
 import org.richfaces.tests.metamer.ftest.annotations.IssueTracking;
 import org.richfaces.tests.metamer.ftest.extension.attributes.coverage.annotations.CoversAttributes;
@@ -45,8 +35,18 @@ import org.richfaces.tests.metamer.ftest.extension.configurator.use.annotation.U
 import org.richfaces.tests.metamer.ftest.extension.configurator.use.annotation.ValuesFrom;
 import org.richfaces.tests.metamer.ftest.richDragIndicator.Indicator;
 import org.testng.annotations.Test;
+import org.wildfly.extras.creaper.core.online.CliException;
 
-import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author <a href="jjamrich@redhat.com">Jan Jamrich</a>
@@ -143,7 +143,7 @@ public class TestDragSource extends AbstractDragSourceTest {
         "https://issues.jboss.org/browse/RF-14251",// not resolved
         "https://issues.jboss.org/browse/RF-10967"
         })
-    public void testDragValueWithPartialStateSavingOff() {
+    public void testDragValueWithPartialStateSavingOff() throws IOException {
         disablePartialStateSavingAndRedeploy();
         openPageWithCurrentConfiguration();
         try {
@@ -152,7 +152,7 @@ public class TestDragSource extends AbstractDragSourceTest {
             try {
                 undeployMetamerWars();
                 deployMetamerWar();
-            } catch (CommandLineException ex) {
+            } catch (CliException ex) {
                 System.err.println(ex);
                 System.err.println("Was not able to deploy the original WAR. Exiting.");
                 System.exit(1);

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/richPickList/TestPickListColumnClasses.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/richPickList/TestPickListColumnClasses.java
@@ -21,8 +21,8 @@
  */
 package org.richfaces.tests.metamer.ftest.richPickList;
 
-import java.text.MessageFormat;
-
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -36,8 +36,7 @@ import org.richfaces.tests.metamer.ftest.extension.configurator.templates.annota
 import org.richfaces.tests.metamer.ftest.webdriver.utils.LazyLoadedCachedValue;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.BoundType;
-import com.google.common.collect.Ranges;
+import java.text.MessageFormat;
 
 /**
  * @author <a href="mailto:jstefek@redhat.com">Jiri Stefek</a>
@@ -63,7 +62,7 @@ public class TestPickListColumnClasses extends AbstractColumnAndRowClassesTest {
     @Override
     public void performAfterSettingOfAttributes() {
         // move some of the items to target list, so the @columnClasses can be also checked there
-        pickList.addMultiple(ChoicePickerHelper.byIndex().fromRange(Ranges.range(0, BoundType.CLOSED, pickList.advanced().getSourceListItemsElements().size() / 2, BoundType.CLOSED)));
+        pickList.addMultiple(ChoicePickerHelper.byIndex().fromRange(Range.range(0, BoundType.CLOSED, pickList.advanced().getSourceListItemsElements().size() / 2, BoundType.CLOSED)));
     }
 
     @Test

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/utils/ManagementClientProvider.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/utils/ManagementClientProvider.java
@@ -1,0 +1,34 @@
+package org.richfaces.tests.metamer.ftest.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.offline.OfflineManagementClient;
+import org.wildfly.extras.creaper.core.offline.OfflineOptions;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+
+/**
+ * Provider for Creaper's OnlineManagementClient
+ */
+public class ManagementClientProvider {
+
+    /**
+     * Creates OnlineManagementClient for standalone server
+     * @return Initialized OnlineManagementClient, don't forget to close it
+     */
+    public static OnlineManagementClient createOnlineManagementClientForStandaloneServer() {
+        return ManagementClient.onlineLazy(OnlineOptions.standalone()
+                .hostAndPort("localhost", 9990)
+                .build());
+    }
+
+    public static OfflineManagementClient createOfflineManagementClientForStandaloneServer() throws IOException {
+        return ManagementClient.offline(OfflineOptions.standalone()
+                .rootDirectory(new File(System.getProperty("JBOSS_HOME")))
+                .configurationFile("standalone.xml")
+                .build());
+    }
+
+}

--- a/metamer/ftest/src/test/resources/arquillian.xml
+++ b/metamer/ftest/src/test/resources/arquillian.xml
@@ -61,6 +61,15 @@ http://www.fsf.org. -->
         </configuration>
     </container>
 
+    <container qualifier="jbosseap-managed-7-1">
+        <configuration>
+            <property name="javaVmArguments">${arquillian.container.jbossas.7-1.jvm.args}</property>
+            <property name="managementAddress">${arquillian.container.jbossas.7-1.node0}</property>
+            <property name="serverConfig">standalone.xml</property>
+            <property name="enableAssertions">false</property>
+        </configuration>
+    </container>
+
     <container qualifier="wildfly-managed-8-1">
         <configuration>
             <property name="javaVmArguments">${arquillian.container.jbossas.7-1.jvm.args}</property>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <arquillian.bom.version>1.1.11.Final</arquillian.bom.version>
         <arquillian.wildfly.container>1.0.1.Final</arquillian.wildfly.container>
         <arquillian.tomcat.version>1.0.0.CR7</arquillian.tomcat.version>
-        <arquillian.drone.version>2.0.0.Final</arquillian.drone.version>
-        <arquillian.graphene.version>2.1.0.CR1</arquillian.graphene.version>
+        <arquillian.drone.version>2.0.1.Final</arquillian.drone.version>
+        <arquillian.graphene.version>2.1.0.Final</arquillian.graphene.version>
         <arquillian.openshift-express>1.0.0.Beta1</arquillian.openshift-express>
         <shrinkwrap.descriptors.version>2.0.0-alpha-9</shrinkwrap.descriptors.version>
 
@@ -78,6 +78,7 @@
         <jbossEAP63Home>${project.build.directory}/jboss-eap-6.3</jbossEAP63Home>
         <jbossEAP64Home>${project.build.directory}/jboss-eap-6.4</jbossEAP64Home>
         <jbossEAP70Home>${project.build.directory}/jboss-eap-7.0</jbossEAP70Home>
+        <jbossEAP71Home>${project.build.directory}/jboss-eap-7.1</jbossEAP71Home>
 
         <wildfly8-1Home>${project.build.directory}/wildfly-${version.wildfly8-1}</wildfly8-1Home>
         <wildfly8-2Home>${project.build.directory}/wildfly-${version.wildfly8-2}</wildfly8-2Home>
@@ -97,6 +98,7 @@
         <apache-commons-io.version>2.4</apache-commons-io.version>
         <google.json.version>1.1</google.json.version>
         <version.mockito>1.8.5</version.mockito>
+        <version.org.wildfly.extras.creaper>1.4.0</version.org.wildfly.extras.creaper>
 
     </properties>
 
@@ -534,6 +536,7 @@
                 <artifactId>mockito-all</artifactId>
                 <version>${version.mockito}</version>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -714,10 +717,36 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>org.wildfly</groupId>
+                    <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>8.2.0.Final</version>
+                    <version>2.0.0.Final</version>
                     <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-controller-client</artifactId>
+                    <version>2.1.0.Final</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-cli</artifactId>
+                    <version>2.1.0.Final</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.jboss.logmanager</groupId>
+                            <artifactId>jboss-logmanager</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
+                <!-- probably a bug in wildfly-cli dependencies -->
+                <!-- not required if the dependency on wildfly-patching below is also added -->
+                <dependency>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                    <version>2.0.3.Final</version>
                 </dependency>
             </dependencies>
             <build>
@@ -732,6 +761,64 @@
                             </systemProperties>
                             <environmentVariables>
                                 <JBOSS_HOME>${jbossEAP70Home}</JBOSS_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jbosseap-managed-7-1</id>
+            <properties>
+                <metamer.classifier>jee6</metamer.classifier>
+                <version.eap>property.version.eap.not.specified</version.eap>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>2.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-controller-client</artifactId>
+                    <version>2.1.0.Final</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-cli</artifactId>
+                    <version>2.1.0.Final</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.jboss.logmanager</groupId>
+                            <artifactId>jboss-logmanager</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
+                <!-- probably a bug in wildfly-cli dependencies -->
+                <!-- not required if the dependency on wildfly-patching below is also added -->
+                <dependency>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                    <version>2.0.3.Final</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <arquillian.launch>jbosseap-managed-7-1</arquillian.launch>
+                                <!-- following is used in tests -->
+                                <JBOSS_HOME>${jbossEAP71Home}</JBOSS_HOME>
+                            </systemProperties>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jbossEAP71Home}</JBOSS_HOME>
                             </environmentVariables>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
- Updated Arquillian dependencies
- Removed conflicting Guava dependencies and replaced it by one artifact (19.0)
- Removed `org.jboss.logging` dependencies and replaced it by one artifact (3.3.0.Final)
- Added `org.jboss.logging` to `MANIFEST.MF` as dependency
- Added Creaper where required
