### PR TITLE
Generating JUnit reports with parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ nb-configuration.xml
 *.iml
 *.ipr
 *.iws
+.idea/
+.recommenders/

--- a/metamer/application/pom.xml
+++ b/metamer/application/pom.xml
@@ -129,7 +129,7 @@ FSF site: http://www.fsf.org. -->
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-            <version>3.15.0-GA</version>
+            <version>3.18.2-GA</version>
         </dependency>
 
         <dependency>

--- a/metamer/ftest/pom.xml
+++ b/metamer/ftest/pom.xml
@@ -38,7 +38,7 @@ FSF site: http://www.fsf.org. -->
             -Djboss.bind.address.unsecure=${arquillian.container.jbossas.7-1.node0}</arquillian.container.jbossas.7-1.jvm.args>
 
         <templates>plain</templates>
-        <testng.listeners>org.richfaces.tests.metamer.ftest.extension.configurator.transformer.DataProviderTestTransformer,org.richfaces.tests.metamer.ftest.MetamerConsoleStatusTestListener,org.richfaces.tests.metamer.ftest.MetamerFailureLoggingTestListener,org.jboss.test.selenium.listener.BrowserConsoleLogSaverListener</testng.listeners>
+        <testng.listeners>org.richfaces.tests.metamer.ftest.extension.configurator.transformer.DataProviderTestTransformer,org.richfaces.tests.metamer.ftest.MetamerConsoleStatusTestListener,org.richfaces.tests.metamer.ftest.MetamerFailureLoggingTestListener,org.jboss.test.selenium.listener.BrowserConsoleLogSaverListener,org.richfaces.tests.metamer.ftest.utils.reporters.JUnitReportReporter,org.testng.reporters.XMLReporter</testng.listeners>
         <testng.suite.xml>src/test/resources/testng/testng-all.xml</testng.suite.xml>
         <metamer-portlet.version>3.2.1.Final</metamer-portlet.version>
         <jboss-portal.version>7.1.3.Final</jboss-portal.version>
@@ -177,6 +177,10 @@ FSF site: http://www.fsf.org. -->
             		<groupId>com.google.guava</groupId>
             		<artifactId>guava</artifactId>
             	</exclusion>
+                <exclusion>
+                    <groupId>javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -220,6 +224,21 @@ FSF site: http://www.fsf.org. -->
         	<groupId>com.google.guava</groupId>
         	<artifactId>guava</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.21.0-GA</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -251,6 +270,10 @@ FSF site: http://www.fsf.org. -->
                         <property>
                             <name>listener</name>
                             <value>${testng.listeners}</value>
+                        </property>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>false</value>
                         </property>
                     </properties>
                     <systemPropertyVariables>
@@ -299,6 +322,14 @@ FSF site: http://www.fsf.org. -->
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -316,6 +347,12 @@ FSF site: http://www.fsf.org. -->
                     <version>1.0.0.Final</version>
                     <type>pom</type>
                     <scope>provided</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>javassist</groupId>
+                            <artifactId>javassist</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.as</groupId>

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/extension/configurator/Configurator.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/extension/configurator/Configurator.java
@@ -21,9 +21,7 @@
  */
 package org.richfaces.tests.metamer.ftest.extension.configurator;
 
-import java.lang.reflect.Method;
-import java.util.List;
-
+import com.google.common.collect.Lists;
 import org.richfaces.tests.metamer.ftest.extension.configurator.config.Config;
 import org.richfaces.tests.metamer.ftest.extension.configurator.repeater.RepeaterConfigurator;
 import org.richfaces.tests.metamer.ftest.extension.configurator.skip.SkipConfigurator;
@@ -32,7 +30,8 @@ import org.richfaces.tests.metamer.ftest.extension.configurator.use.UseForAllTes
 import org.richfaces.tests.metamer.ftest.extension.configurator.use.UseWithFieldConfigurator;
 import org.richfaces.tests.metamer.ftest.extension.configurator.use.UsesConfigurator;
 
-import com.google.common.collect.Lists;
+import java.lang.reflect.Method;
+import java.util.List;
 
 /**
  * @author <a href="mailto:jstefek@redhat.com">Jiri Stefek</a>
@@ -71,6 +70,10 @@ public class Configurator {
         return createInvocationsOfTestMethod(manager.createAllConfigurations(m, testInstance));
     }
 
+    public List<List<Config>> getConfigurations() {
+        return manager.getConfigurations();
+    }
+
     private static class ConfigManager {
 
         private final List<List<Config>> configurations = Lists.newLinkedList();
@@ -99,6 +102,10 @@ public class Configurator {
 
         public Config getNextConfigurationStep() {
             return configurations.get(0).remove(0);
+        }
+
+        public List<List<Config>> getConfigurations() {
+            return configurations;
         }
     }
 }

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/richAccordion/TestAccordion.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/richAccordion/TestAccordion.java
@@ -21,14 +21,6 @@
  */
 package org.richfaces.tests.metamer.ftest.richAccordion;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
-import java.util.List;
-
-import javax.faces.event.PhaseId;
-
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.graphene.page.Page;
 import org.openqa.selenium.WebElement;
@@ -45,6 +37,14 @@ import org.richfaces.tests.metamer.ftest.extension.configurator.templates.annota
 import org.richfaces.tests.metamer.ftest.webdriver.Attributes;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import javax.faces.event.PhaseId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
@@ -107,10 +107,10 @@ public class TestAccordion extends AbstractWebDriverTest {
     public void testCycledSwitching() {
         WebElement rootElement = page.getAccordion().advanced().getRootElement();
         // RichFaces.$('form:accordion').nextItem('item5') will be null
-        assertEquals(Utils.invokeRichFacesJSAPIFunction(rootElement, "nextItem('item5')"), null, "Result of function nextItem('item5')");
+        assertEquals(Optional.ofNullable(Utils.invokeRichFacesJSAPIFunction(rootElement, "nextItem('item5')")), Optional.empty(), "Result of function nextItem('item5')");
 
         // RichFaces.$('form:accordion').prevItem('item1') will be null
-        assertEquals(Utils.invokeRichFacesJSAPIFunction(rootElement, "prevItem('item1')"), null, "Result of function prevItem('item1')");
+        assertEquals(Optional.ofNullable(Utils.invokeRichFacesJSAPIFunction(rootElement, "prevItem('item1')")), Optional.empty(), "Result of function prevItem('item1')");
 
         accordionAttributes.set(AccordionAttributes.cycledSwitching, true);
 

--- a/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/utils/reporters/JUnitReportReporter.java
+++ b/metamer/ftest/src/test/java/org/richfaces/tests/metamer/ftest/utils/reporters/JUnitReportReporter.java
@@ -1,0 +1,323 @@
+package org.richfaces.tests.metamer.ftest.utils.reporters;
+
+import org.apache.commons.lang.StringUtils;
+import org.richfaces.tests.metamer.ftest.extension.configurator.config.Config;
+import org.richfaces.tests.utils.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.IReporter;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.collections.ListMultiMap;
+import org.testng.collections.Lists;
+import org.testng.collections.Maps;
+import org.testng.collections.Sets;
+import org.testng.internal.Utils;
+import org.testng.reporters.XMLConstants;
+import org.testng.reporters.XMLStringBuffer;
+import org.testng.xml.XmlSuite;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class JUnitReportReporter implements IReporter {
+
+    private static final Logger log = LoggerFactory.getLogger(JUnitReportReporter.class);
+
+    private static final AtomicInteger testMethodCounter = new AtomicInteger(0);
+
+    @Override
+    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
+                               String defaultOutputDirectory) {
+
+        Map<Class<?>, Set<ITestResult>> results = Maps.newHashMap();
+        Map<Class<?>, Set<ITestResult>> failedConfigurations = Maps.newHashMap();
+        ListMultiMap<Object, ITestResult> befores = Maps.newListMultiMap();
+        ListMultiMap<Object, ITestResult> afters = Maps.newListMultiMap();
+        for (ISuite suite : suites) {
+            Map<String, ISuiteResult> suiteResults = suite.getResults();
+            for (ISuiteResult sr : suiteResults.values()) {
+                ITestContext tc = sr.getTestContext();
+                addResults(tc.getPassedTests().getAllResults(), results);
+                addResults(tc.getFailedTests().getAllResults(), results);
+                addResults(tc.getSkippedTests().getAllResults(), results);
+                addResults(tc.getFailedConfigurations().getAllResults(), failedConfigurations);
+                for (ITestResult tr : tc.getPassedConfigurations().getAllResults()) {
+                    if (tr.getMethod().isBeforeMethodConfiguration()) {
+                        befores.put(tr.getInstance(), tr);
+                    }
+                    if (tr.getMethod().isAfterMethodConfiguration()) {
+                        afters.put(tr.getInstance(), tr);
+                    }
+                }
+            }
+        }
+
+        // A list of iterators for all the passed configuration, explanation below
+//    ListMultiMap<Class<?>, ITestResult> beforeConfigurations = Maps.newListMultiMap();
+//    ListMultiMap<Class<?>, ITestResult> afterConfigurations = Maps.newListMultiMap();
+//    for (Map.Entry<Class<?>, Set<ITestResult>> es : passedConfigurations.entrySet()) {
+//      for (ITestResult tr : es.getValue()) {
+//        ITestNGMethod method = tr.getMethod();
+//        if (method.isBeforeMethodConfiguration()) {
+//          beforeConfigurations.put(method.getRealClass(), tr);
+//        }
+//        if (method.isAfterMethodConfiguration()) {
+//          afterConfigurations.put(method.getRealClass(), tr);
+//        }
+//      }
+//    }
+//    Map<Object, Iterator<ITestResult>> befores = Maps.newHashMap();
+//    for (Map.Entry<Class<?>, List<ITestResult>> es : beforeConfigurations.getEntrySet()) {
+//      List<ITestResult> tr = es.getValue();
+//      for (ITestResult itr : es.getValue()) {
+//      }
+//    }
+//    Map<Class<?>, Iterator<ITestResult>> afters = Maps.newHashMap();
+//    for (Map.Entry<Class<?>, List<ITestResult>> es : afterConfigurations.getEntrySet()) {
+//      afters.put(es.getKey(), es.getValue().iterator());
+//    }
+
+        for (Map.Entry<Class<?>, Set<ITestResult>> entry : results.entrySet()) {
+            Class<?> cls = entry.getKey();
+            Properties p1 = new Properties();
+            p1.setProperty("name", cls.getName());
+            Date timeStamp = Calendar.getInstance().getTime();
+            p1.setProperty(XMLConstants.ATTR_TIMESTAMP, timeStamp.toGMTString());
+
+            List<TestTag> testCases = Lists.newArrayList();
+            int failures = 0;
+            int errors = 0;
+            int testCount = 0;
+            float totalTime = 0;
+
+            String previousName = null;
+
+            Comparator<ITestResult> alphabetOrderComparator = Comparator.comparing(result -> result.getMethod().getMethodName());
+            List<ITestResult> sortedResults = entry.getValue().stream()
+                    .sorted(alphabetOrderComparator)
+                    .collect(Collectors.toList());
+            for (ITestResult tr : sortedResults) {
+
+                //update counter to access right params
+                final String methodName = tr.getMethod().getMethodName();
+                if (methodName.equals(previousName)) {
+                    testMethodCounter.getAndIncrement();
+                } else {
+                    testMethodCounter.set(0);
+                }
+                previousName = methodName;
+
+                TestTag testTag = new TestTag();
+
+                boolean isSuccess = tr.getStatus() == ITestResult.SUCCESS;
+                if (!isSuccess) {
+                    if (tr.getThrowable() instanceof AssertionError) {
+                        failures++;
+                    } else {
+                        errors++;
+                    }
+                }
+
+                Properties p2 = new Properties();
+                p2.setProperty("classname", cls.getName());
+                p2.setProperty("name", getTestName(tr));
+                long time = tr.getEndMillis() - tr.getStartMillis();
+
+                time += getNextConfiguration(befores, tr);
+                time += getNextConfiguration(afters, tr);
+
+                p2.setProperty("time", "" + formatTime(time));
+                Throwable t = getThrowable(tr, failedConfigurations);
+                if (!isSuccess && t != null) {
+                    StringWriter sw = new StringWriter();
+                    PrintWriter pw = new PrintWriter(sw);
+                    t.printStackTrace(pw);
+                    testTag.message = t.getMessage();
+                    testTag.type = t.getClass().getName();
+                    testTag.stackTrace = sw.toString();
+                    testTag.errorTag = tr.getThrowable() instanceof AssertionError ? "failure" : "error";
+                }
+                totalTime += time;
+                testCount++;
+                testTag.properties = p2;
+                testCases.add(testTag);
+            }
+
+            p1.setProperty("failures", "" + failures);
+            p1.setProperty("errors", "" + errors);
+            p1.setProperty("name", cls.getName());
+            p1.setProperty("tests", "" + testCount);
+            p1.setProperty("time", "" + formatTime(totalTime));
+            try {
+                p1.setProperty(XMLConstants.ATTR_HOSTNAME, InetAddress.getLocalHost().getHostName());
+            } catch (UnknownHostException e) {
+                // ignore
+            }
+
+            //
+            // Now that we have all the information we need, generate the file
+            //
+            XMLStringBuffer xsb = new XMLStringBuffer();
+            xsb.addComment("Generated by " + getClass().getName());
+
+            xsb.push("testsuite", p1);
+            for (TestTag testTag : testCases) {
+                if (testTag.stackTrace == null) {
+                    xsb.addEmptyElement("testcase", testTag.properties);
+                } else {
+                    xsb.push("testcase", testTag.properties);
+
+                    Properties p = new Properties();
+                    if (testTag.message != null) {
+                        p.setProperty("message", testTag.message);
+                    }
+                    p.setProperty("type", testTag.type);
+                    xsb.push(testTag.errorTag, p);
+                    xsb.addCDATA(testTag.stackTrace);
+                    xsb.pop(testTag.errorTag);
+
+                    xsb.pop("testcase");
+                }
+            }
+            xsb.pop("testsuite");
+
+            String outputDirectory = defaultOutputDirectory + File.separator + "junitreports";
+            Utils.writeUtf8File(outputDirectory, getFileName(cls), xsb.toXML());
+        }
+
+//    System.out.println(xsb.toXML());
+//    System.out.println("");
+
+    }
+
+    /**
+     * Add the time of the configuration method to this test method.
+     * <p>
+     * The only problem with this method is that the timing of a test method
+     * might not be added to the time of the same configuration method that ran before
+     * it but since they should all be equivalent, this should never be an issue.
+     */
+    private long getNextConfiguration(ListMultiMap<Object, ITestResult> configurations, ITestResult tr) {
+        long result = 0;
+
+        List<ITestResult> confResults = configurations.get(tr.getInstance());
+        Map<ITestNGMethod, ITestResult> seen = Maps.newHashMap();
+        if (confResults != null) {
+            for (ITestResult r : confResults) {
+                if (!seen.containsKey(r.getMethod())) {
+                    result += r.getEndMillis() - r.getStartMillis();
+                    seen.put(r.getMethod(), r);
+                }
+            }
+            confResults.removeAll(seen.values());
+        }
+
+        return result;
+    }
+
+    protected String getFileName(Class cls) {
+        return "TEST-" + cls.getName() + ".xml";
+    }
+
+    private String generateParametrizedTestName(String name, ITestResult result) {
+        StringBuilder stringBuilder = new StringBuilder()
+                .append(name)
+                .append("(");
+        final Object testInstance = result.getInstance();
+        if (testInstance != null) {
+            Map<String, List<Config>> configurations = null;
+            try {
+                Field configField = ReflectionUtils.getFirstFieldWithName("configurations", testInstance);
+                configurations = (Map<String, List<Config>>) ReflectionUtils.getFieldValue(configField, testInstance);
+                log.info("CONFIGURATIONS, {}, index: {}", configurations, testMethodCounter.get());
+            } catch (Exception ex) {
+                ex.printStackTrace(System.err);
+            }
+
+            List<String> info = new LinkedList<>();
+            if (configurations != null) {
+                if (!configurations.isEmpty()) {
+                    info.add(configurations.get(name).get(testMethodCounter.get()).toString());
+                }
+            }
+            stringBuilder.append(StringUtils.join(info, "; "));
+        }
+        stringBuilder.append(")");
+        return stringBuilder.toString();
+    }
+
+    protected String getTestName(ITestResult tr) {
+        return generateParametrizedTestName(tr.getMethod().getMethodName(), tr);
+    }
+
+    private String formatTime(float time) {
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols();
+        // JUnitReports wants points here, regardless of the locale
+        symbols.setDecimalSeparator('.');
+        DecimalFormat format = new DecimalFormat("#.###", symbols);
+        format.setMinimumFractionDigits(3);
+        return format.format(time / 1000.0f);
+    }
+
+    private Throwable getThrowable(ITestResult tr,
+                                   Map<Class<?>, Set<ITestResult>> failedConfigurations) {
+        Throwable result = tr.getThrowable();
+        if (result == null && tr.getStatus() == ITestResult.SKIP) {
+            // Attempt to grab the stack trace from the configuration failure
+            for (Set<ITestResult> failures : failedConfigurations.values()) {
+                for (ITestResult failure : failures) {
+                    // Naive implementation for now, eventually, we need to try to find
+                    // out if it's this failure that caused the skip since (maybe by
+                    // seeing if the class of the configuration method is assignable to
+                    // the class of the test method, although that's not 100% fool proof
+                    if (failure.getThrowable() != null) {
+                        return failure.getThrowable();
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    static class TestTag {
+        public Properties properties;
+        public String message;
+        public String type;
+        public String stackTrace;
+        public String errorTag;
+    }
+
+    private void addResults(Set<ITestResult> allResults, Map<Class<?>, Set<ITestResult>> out) {
+        for (ITestResult tr : allResults) {
+            Class<?> cls = tr.getMethod().getTestClass().getRealClass();
+            Set<ITestResult> l = out.get(cls);
+            if (l == null) {
+                l = Sets.newHashSet();
+                out.put(cls, l);
+            }
+            l.add(tr);
+        }
+    }
+
+}

--- a/metamer/ftest/src/test/resources/logback.xml
+++ b/metamer/ftest/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36}: %msg%n</pattern>
+            <!-- pattern format: http://logback.qos.ch/manual/layouts.html#conversionWord -->
+        </encoder>
+    </appender>
+
+    <logger name="org.jboss.hal.testsuite" level="DEBUG"/>
+    <logger name="org.apache.http" level="WARN"/>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,16 @@
                 <version>${version.mockito}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.6</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/testng-listeners/pom.xml
+++ b/testng-listeners/pom.xml
@@ -46,6 +46,15 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/testng-listeners/src/main/java/org/jboss/test/selenium/listener/ConsoleStatusTestListener.java
+++ b/testng-listeners/src/main/java/org/jboss/test/selenium/listener/ConsoleStatusTestListener.java
@@ -22,6 +22,8 @@
 package org.jboss.test.selenium.listener;
 
 import org.jboss.test.selenium.utils.testng.TestLoggingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 
@@ -33,6 +35,8 @@ import org.testng.TestListenerAdapter;
  * @version $Revision$
  */
 public class ConsoleStatusTestListener extends TestListenerAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsoleStatusTestListener.class);
 
     @Override
     public void onTestStart(ITestResult result) {
@@ -62,15 +66,14 @@ public class ConsoleStatusTestListener extends TestListenerAdapter {
     /**
      * This method will output method name and status on the standard output
      *
-     * @param result
-     *            from the fine-grained listener's method such as onTestFailure(ITestResult)
+     * @param result from the fine-grained listener's method such as onTestFailure(ITestResult)
      */
     private void logStatus(ITestResult result) {
         String message = getMessage(result);
-        System.out.println(message);
-        if (result.getStatus() != ITestResult.STARTED) {
+        log.info(message);
+        /*if (result.getStatus() != ITestResult.STARTED) {
             System.out.println();
-        }
+        }*/
     }
 
     protected String getMessage(ITestResult result) {

--- a/testng-listeners/src/main/java/org/jboss/test/selenium/utils/testng/TestLoggingUtils.java
+++ b/testng-listeners/src/main/java/org/jboss/test/selenium/utils/testng/TestLoggingUtils.java
@@ -21,12 +21,12 @@
  */
 package org.jboss.test.selenium.utils.testng;
 
-import static org.jboss.test.selenium.utils.testng.TestInfo.STATUSES;
-import static org.jboss.test.selenium.utils.testng.TestInfo.getPackageClassMethodName;
+import org.testng.ITestResult;
 
 import java.util.Date;
 
-import org.testng.ITestResult;
+import static org.jboss.test.selenium.utils.testng.TestInfo.STATUSES;
+import static org.jboss.test.selenium.utils.testng.TestInfo.getPackageClassMethodName;
 
 /**
  * Provides the method for obtaining test description from ITestResult.
@@ -62,8 +62,6 @@ public final class TestLoggingUtils {
         parameters.append(")");
 
         // result
-        String message =
-            String.format("[%tT] %s: %s%s", new Date(), status.toUpperCase(), methodName, parameters.toString());
-        return message;
+        return String.format("[%tT] %s: %s%s", new Date(), status.toUpperCase(), methodName, parameters.toString());
     }
 }

--- a/testng-listeners/src/main/resources/logback.xml
+++ b/testng-listeners/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36}: %msg%n</pattern>
+            <!-- pattern format: http://logback.qos.ch/manual/layouts.html#conversionWord -->
+        </encoder>
+    </appender>
+
+    <logger name="org.jboss.hal.testsuite" level="DEBUG"/>
+    <logger name="org.apache.http" level="WARN"/>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
* Updated javassist dependency, since the version provided by other artifacts was incompatible with Java 1.8
* Customized JUnit reporter to report test names with parameters
* Customized main abstract test to contain all configuration for given test
* Replaced as many `System.out.println()` by slf4j as I could